### PR TITLE
チャット画面の自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,3 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
-//= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -6,7 +6,7 @@ $(function() {
               <img src="${message.image}", class="chat-main__content__message-block__image">`
               : "";
 
-    var html = `<div class="chat-main__content__message-block">
+    var html = `<div class="chat-main__content__message-block" data-id="${message.id}">
                   <p class="chat-main__content__message-block__name">
                     ${message.user_name}
                   </p>
@@ -46,4 +46,33 @@ $(function() {
       $(".chat-main__footer__form__send-button").prop("disabled", false);
     });
   });
+
+
+  setInterval(update, 5000);
+
+  function update(){
+    if($(".chat-main__content__message-block")[0]){
+    var messageId = $(".chat-main__content__message-block:last").data("id");
+  } else {
+    var messageId = 0;
+  }
+    $.ajax({
+      url: location.href,
+      type: 'GET',
+      data: { lastMessage: messageId },
+      dataType: 'json'
+    })
+    .done(function(messages){
+      var insertHTML = "";
+      if (messages.length !== 0) {
+      messages.forEach(function(message){
+          insertHTML += buildHTML(message);
+      });
+      $(".chat-main__content").append(insertHTML);
+      }
+    })
+    .fail(function(data){
+      alert("自動更新に失敗しました")
+    });
+  }
 });

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,11 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+    @new_messages = @group.messages.where('id > ?', params[:lastMessage])
+      respond_to do |format|
+        format.html
+        format.json
+      end
   end
 
   def create

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,5 @@
+= javascript_include_tag 'search.js'
+
 .chat-group-form
   %h1 チャットグループ編集
   = render 'form', { group: @group }

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,8 +1,8 @@
-.chat-main__content__message-block
+.chat-main__content__message-block{data: {id: message.id} }
   %p.chat-main__content__message-block__name
     = message.user.name
   %p.chat-main__content__message-block__time
-    = message.created_at
+    = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
   - if message.comment.present?
     %p.chat-main__content__message-block__text
       = message.comment

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
 json.comment @message.comment
 json.image @message.image.url
 json.user_name @message.user.name
-json.time @message.created_at
+json.time @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.id @message.id

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,3 +1,5 @@
+= javascript_include_tag 'message.js'
+
 = render "layouts/side_bar"
 
 / mainview

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @new_messages do |message|
+  json.comment message.comment
+  json.image message.image.url
+  json.user_name message.user.name
+  json.time message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.id message.id
+end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,5 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( message.js )


### PR DESCRIPTION
# WHAT
チャット画面の自動更新機能を実装
以下のエンドポイントを実装。

・messages_controllerで
　@new_messages = @group.messages.where('id > ?', params[:lastMessage])で
　最後のメッセージの要素のidより大きいidのレコードがmessagesテーブルにあれば、
　@new_messagesに代入するよう定義。
・messages/index.json.jbuilderで新しく追加されたjsonリクエストを
　配列@new_messagesをdone(messages)に返すよう設定。
・message.jsにて自動更新機能の関数updateを実装。
・data: { lastMessage: messageId }でlastMessageをキーとして、
　現在表示されている最後のメッセージ要素のidが入った変数messageIdを値として、
　ajax通信でパラメーターとして、messages_controllerに送信するよう設定。
・done(function(messages)で受け取った新規メッセージを追加するよう定義。
・strftime("%Y年%m月%d日 %H時%M分")で投稿された時間を日本時間で表示するよう修正。
・jsファイルを特定のページでのみ適用させるように、//= require_tree .を削除。
　config/initializers/assets.rbにて使用するjsファイルを予めプリコンパイル対象に指定。

# WHY
グループの他のメンバーがメッセージを投稿した際に、リロードしなくてもそのメッセージが見れるように自動でアップデートできるようにするため。

・新規メッセージのみ非同期でHTMLを追加できるように、
　現在表示されているメッセージのidとデータベースに存在するmessagesテーブルのidとの差分で
　自動更新で追加するよう実装しました。
・投稿時間を日本時間に変更した方が日本人にわかりやすいと思ったため、
　変更しました。
・他のページを表示している際に自動更新が実行されないように、
　特定のviewでのみjsファイルが適用されるように変更しました。